### PR TITLE
[1#] 프로젝트 피드백 반영 수정

### DIFF
--- a/src/main/java/com/example/bootproject/common/ApplicationYamlRead.java
+++ b/src/main/java/com/example/bootproject/common/ApplicationYamlRead.java
@@ -1,0 +1,23 @@
+package com.example.bootproject.common;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationYamlRead {
+    @Getter
+    static int modifiableDateValue;
+    @Getter
+    static int modificationLimitValue;
+
+    @Value("${constant-data.modifiable-date-value}")
+    public void setModifiedDate(int modifiableDateValue){
+        ApplicationYamlRead.modifiableDateValue = modifiableDateValue;
+
+    }
+    @Value("${constant-data.modification-limit-value}")
+    public void setModificationLimit(int modificationLimitValue){
+        ApplicationYamlRead.modificationLimitValue = modificationLimitValue;
+    }
+}

--- a/src/main/java/com/example/bootproject/enums/DeleteType.java
+++ b/src/main/java/com/example/bootproject/enums/DeleteType.java
@@ -1,0 +1,5 @@
+package com.example.bootproject.enums;
+
+public enum DeleteType {
+    SOFT, HARD;
+}

--- a/src/main/java/com/example/bootproject/enums/SortOrder.java
+++ b/src/main/java/com/example/bootproject/enums/SortOrder.java
@@ -1,0 +1,5 @@
+package com.example.bootproject.enums;
+
+public enum SortOrder {
+    ASC, DESC;
+}

--- a/src/main/java/com/example/bootproject/exception/BadRequestException.java
+++ b/src/main/java/com/example/bootproject/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package com.example.bootproject.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/bootproject/exception/NotFoundException.java
+++ b/src/main/java/com/example/bootproject/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.bootproject.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/bootproject/post/controller/PostController.java
+++ b/src/main/java/com/example/bootproject/post/controller/PostController.java
@@ -24,23 +24,17 @@ public class PostController {
 
     @GetMapping("/api/posts/all")
     public List<Post> allPosts() {
-        List<Post> posts = postService.allPostList();
-
-        return posts;
+        return postService.allPostList();
     }
 
     @GetMapping("/api/posts/{postId}")
     public PostDetailDTO getPost(@PathVariable("postId") Long id) {
-        PostDetailDTO postDetailDTO = postService.getPost(id);
-
-        return postDetailDTO;
+        return postService.getPost(id);
     }
 
     @GetMapping("/api/posts")
     public List<PostDetailDTO> searchPost(PostSearch search) {
-        List<PostDetailDTO> postDetails = postService.postListSearch(search);
-
-        return postDetails;
+        return postService.postListSearch(search);
     }
 
     @PostMapping("/api/posts")
@@ -52,9 +46,7 @@ public class PostController {
 
     @PutMapping("/api/posts/{postId}")
     public PostUpdateDTO updatePost(@PathVariable("postId") Long id, @RequestBody PostRegistDTO postRegistDTO) {
-        PostUpdateDTO postUpdate = postService.updatePost(postRegistDTO, id);
-
-        return postUpdate;
+        return postService.updatePost(postRegistDTO, id);
     }
 
     @DeleteMapping("/api/posts/{postId}")

--- a/src/main/java/com/example/bootproject/post/controller/PostController.java
+++ b/src/main/java/com/example/bootproject/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.example.bootproject.post.controller;
 
+import com.example.bootproject.enums.DeleteType;
 import com.example.bootproject.post.domain.Post;
 import com.example.bootproject.post.domain.PostSearch;
 import com.example.bootproject.post.dto.PostDetailDTO;
@@ -7,6 +8,7 @@ import com.example.bootproject.post.dto.PostRegistDTO;
 import com.example.bootproject.post.dto.PostUpdateDTO;
 import com.example.bootproject.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -36,27 +38,31 @@ public class PostController {
 
     @GetMapping("/api/posts")
     public List<PostDetailDTO> searchPost(PostSearch search) {
-        List<PostDetailDTO> postDetailDTOS = postService.postListSearch(search);
+        List<PostDetailDTO> postDetails = postService.postListSearch(search);
 
-        return postDetailDTOS;
+        return postDetails;
     }
 
     @PostMapping("/api/posts")
     public ResponseEntity<PostDetailDTO> insertPost(@RequestBody PostRegistDTO post) {
-        PostDetailDTO postDetailDTO = postService.insertPost(post);
+        PostDetailDTO postDetail = postService.savePost(post);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(postDetailDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(postDetail);
     }
 
     @PutMapping("/api/posts/{postId}")
     public PostUpdateDTO updatePost(@PathVariable("postId") Long id, @RequestBody PostRegistDTO postRegistDTO) {
-        PostUpdateDTO postUpdateDTO = postService.updatePost(postRegistDTO, id);
+        PostUpdateDTO postUpdate = postService.updatePost(postRegistDTO, id);
 
-        return postUpdateDTO;
+        return postUpdate;
     }
 
     @DeleteMapping("/api/posts/{postId}")
-    public void deletePost(@PathVariable("postId") Long id) {
-        postService.deletePost(id);
+    public void deletePost(@PathVariable("postId") Long id, @RequestParam("deleteType") DeleteType deleteType) {
+        if (deleteType.equals(DeleteType.HARD)){
+            postService.deletePost(id);
+        } else {
+            postService.softDeletePost(id);
+        }
     }
 }

--- a/src/main/java/com/example/bootproject/post/controller/PostController.java
+++ b/src/main/java/com/example/bootproject/post/controller/PostController.java
@@ -29,30 +29,30 @@ public class PostController {
 
     @GetMapping("/api/posts/{postId}")
     public PostDetailDTO getPost(@PathVariable("postId") Long id) {
-        PostDetailDTO postDetail = postService.getPost(id);
+        PostDetailDTO postDetailDTO = postService.getPost(id);
 
-        return postDetail;
+        return postDetailDTO;
     }
 
     @GetMapping("/api/posts")
     public List<PostDetailDTO> searchPost(PostSearch search) {
-        List<PostDetailDTO> postDetails = postService.postListSearch(search);
+        List<PostDetailDTO> postDetailDTOS = postService.postListSearch(search);
 
-        return postDetails;
+        return postDetailDTOS;
     }
 
     @PostMapping("/api/posts")
     public ResponseEntity<PostDetailDTO> insertPost(@RequestBody PostRegistDTO post) {
-        PostDetailDTO postDetail = postService.insertPost(post);
+        PostDetailDTO postDetailDTO = postService.insertPost(post);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(postDetail);
+        return ResponseEntity.status(HttpStatus.CREATED).body(postDetailDTO);
     }
 
     @PutMapping("/api/posts/{postId}")
-    public PostUpdateDTO updatePost(@PathVariable("postId") Long id, @RequestBody PostRegistDTO postRegist) {
-        PostUpdateDTO postUpdate = postService.updatePost(postRegist, id);
+    public PostUpdateDTO updatePost(@PathVariable("postId") Long id, @RequestBody PostRegistDTO postRegistDTO) {
+        PostUpdateDTO postUpdateDTO = postService.updatePost(postRegistDTO, id);
 
-        return postUpdate;
+        return postUpdateDTO;
     }
 
     @DeleteMapping("/api/posts/{postId}")

--- a/src/main/java/com/example/bootproject/post/controller/PostController.java
+++ b/src/main/java/com/example/bootproject/post/controller/PostController.java
@@ -6,55 +6,57 @@ import com.example.bootproject.post.dto.PostDetailDTO;
 import com.example.bootproject.post.dto.PostRegistDTO;
 import com.example.bootproject.post.dto.PostUpdateDTO;
 import com.example.bootproject.post.service.PostService;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.*;
+import java.util.List;
 
 @RestController
-@RequestMapping(value = "/api/posts")
-@AllArgsConstructor
+//초기화 되지 않은 final 필드나, @NonNull 이 붙은 필드에 대해 생성자를 생성해 준다(생성자 주입)
+@RequiredArgsConstructor
 public class PostController {
 
-    private PostService postService;
+    private final PostService postService;
 
-    @GetMapping("/all")
-    public ResponseEntity<List<Post>> allPosts(){
+    @GetMapping("/api/posts/all")
+    public List<Post> allPosts() {
         List<Post> posts = postService.allPostList();
-        return ResponseEntity.ok().body(posts);
+
+        return posts;
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<PostDetailDTO> getPost(@PathVariable("id") Long id){
-        return ResponseEntity.ok().body(postService.getPost(id));
+    @GetMapping("/api/posts/{postId}")
+    public PostDetailDTO getPost(@PathVariable("postId") Long id) {
+        PostDetailDTO postDetail = postService.getPost(id);
+
+        return postDetail;
     }
 
-    @GetMapping("")
-    public ResponseEntity<List<PostDetailDTO>> searchPost(PostSearch search){
-        return ResponseEntity.ok().body(postService.postListSearch(search));
+    @GetMapping("/api/posts")
+    public List<PostDetailDTO> searchPost(PostSearch search) {
+        List<PostDetailDTO> postDetails = postService.postListSearch(search);
+
+        return postDetails;
     }
 
-    @PostMapping("")
-    public ResponseEntity<PostDetailDTO> insertPost(@RequestBody PostRegistDTO post){
-        return ResponseEntity.ok().body(postService.insertPost(post));
+    @PostMapping("/api/posts")
+    public ResponseEntity<PostDetailDTO> insertPost(@RequestBody PostRegistDTO post) {
+        PostDetailDTO postDetail = postService.insertPost(post);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(postDetail);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<PostUpdateDTO> updatePost(@PathVariable("id") Long id,@RequestBody PostRegistDTO post){
-        return ResponseEntity.ok().body(postService.updatePost(post, id));
+    @PutMapping("/api/posts/{postId}")
+    public PostUpdateDTO updatePost(@PathVariable("postId") Long id, @RequestBody PostRegistDTO postRegist) {
+        PostUpdateDTO postUpdate = postService.updatePost(postRegist, id);
+
+        return postUpdate;
     }
 
-    @DeleteMapping("/{id}/soft")
-    public ResponseEntity softDeletePost(@PathVariable("id") Long id){
-        postService.softDeletePost(id);
-        return ResponseEntity.ok().body("success");
-    }
-
-    @DeleteMapping("/{id}")
-    public ResponseEntity deletePost(@PathVariable("id") Long id){
+    @DeleteMapping("/api/posts/{postId}")
+    public void deletePost(@PathVariable("postId") Long id) {
         postService.deletePost(id);
-        return ResponseEntity.ok().body("success");
     }
-
 }

--- a/src/main/java/com/example/bootproject/post/domain/BaseEntity.java
+++ b/src/main/java/com/example/bootproject/post/domain/BaseEntity.java
@@ -2,10 +2,12 @@ package com.example.bootproject.post.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 public class BaseEntity {
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/bootproject/post/domain/Post.java
+++ b/src/main/java/com/example/bootproject/post/domain/Post.java
@@ -1,40 +1,56 @@
 package com.example.bootproject.post.domain;
 
 
+import com.example.bootproject.common.ApplicationYamlRead;
 import com.example.bootproject.post.dto.PostDetailDTO;
-import com.example.bootproject.post.service.PostService;
 import lombok.*;
 
-import javax.validation.constraints.Pattern;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-public class Post extends BaseEntity{
+public class Post extends BaseEntity {
 
     private Long id;
     private String title;
     private String content;
 
+    public static class PostBuilder {
 
-    public static class PostBuilder{
-
-        public PostBuilder title(String title){
-            if(!title.matches("^.{3,200}")){
+        public PostBuilder title(String title) {
+            if (!title.matches("^.{3,200}")) {
                 throw new IllegalArgumentException("제목 200글자 이하로");
             }
             this.title = title;
             return this;
         }
 
-        public PostBuilder content(String content){
-            if(!title.matches("^.{0,1000}")){
+        public PostBuilder content(String content) {
+            if (!title.matches("^.{0,1000}")) {
                 throw new IllegalArgumentException("게시글 1000글자 이내로");
             }
             this.content = content;
             return this;
         }
+    }
+
+    public static PostDetailDTO toPostDetailDTO(Post post) {
+        return PostDetailDTO.builder().id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .modifiableDate(getModifiableDate(post.getCreatedAt()))
+                .build();
+    }
+
+    public static long getModifiableDate(LocalDateTime date) {
+        LocalDateTime nowDate = LocalDateTime.now();
+        int modifiableDate = ApplicationYamlRead.getModifiableDateValue();
+
+        return modifiableDate - ChronoUnit.DAYS.between(date, nowDate);
     }
 }

--- a/src/main/java/com/example/bootproject/post/domain/Post.java
+++ b/src/main/java/com/example/bootproject/post/domain/Post.java
@@ -1,52 +1,38 @@
 package com.example.bootproject.post.domain;
 
 
-import com.example.bootproject.common.ApplicationYamlRead;
 import com.example.bootproject.post.dto.PostDetailDTO;
-import com.example.bootproject.post.service.PostService;
 import lombok.*;
-import org.springframework.beans.factory.annotation.Value;
-
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 
 @Getter
 @Setter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 public class Post extends BaseEntity {
 
     private Long id;
     private String title;
     private String content;
 
-    public static class PostBuilder {
-
-        public PostBuilder title(String title) {
-            if (!title.matches("^.{3,200}$")) {
-                throw new IllegalArgumentException("Content must be up to 200 characters.");
-            }
-            this.title = title;
-            return this;
+    @Builder
+    public Post(Long id, String title, String content) {
+        if (title != null && !title.matches("^.{3,200}$")) {
+            throw new IllegalArgumentException("Title must be up to 200 characters.");
         }
-
-        public PostBuilder content(String content) {
-            if (content != null && !content.matches("^.{0,1000}$")) {
-                throw new IllegalArgumentException("Content must be up to 1000 characters.");
-            }
-            this.content = content;
-            return this;
+        if (content != null && !content.matches("^.{0,1000}$")) {
+            throw new IllegalArgumentException("Content must be up to 1000 characters.");
         }
+        this.id = id;
+        this.title = title;
+        this.content = content;
     }
 
-    public static PostDetailDTO toPostDetailDTO(Post post) {
-        return PostDetailDTO.builder().id(post.getId())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .createdAt(post.getCreatedAt())
-                .updatedAt(post.getUpdatedAt())
-                .modifiableDate(PostService.getModifiableDate(post.getCreatedAt()))
+    public PostDetailDTO toPostDetailDTO(long modifiableDate) {
+        return PostDetailDTO.builder().id(id)
+                .title(title)
+                .content(content)
+                .createdAt(getCreatedAt())
+                .updatedAt(getUpdatedAt())
+                .modifiableDate(modifiableDate)
                 .build();
     }
 }

--- a/src/main/java/com/example/bootproject/post/domain/Post.java
+++ b/src/main/java/com/example/bootproject/post/domain/Post.java
@@ -21,16 +21,16 @@ public class Post extends BaseEntity {
     public static class PostBuilder {
 
         public PostBuilder title(String title) {
-            if (!title.matches("^.{3,200}")) {
-                throw new IllegalArgumentException("제목 200글자 이하로");
+            if (!title.matches("^.{3,200}$")) {
+                throw new IllegalArgumentException("Content must be up to 200 characters.");
             }
             this.title = title;
             return this;
         }
 
         public PostBuilder content(String content) {
-            if (!title.matches("^.{0,1000}")) {
-                throw new IllegalArgumentException("게시글 1000글자 이내로");
+            if (!title.matches("^.{0,1000}$")) {
+                throw new IllegalArgumentException("Content must be up to 1000 characters.");
             }
             this.content = content;
             return this;

--- a/src/main/java/com/example/bootproject/post/domain/Post.java
+++ b/src/main/java/com/example/bootproject/post/domain/Post.java
@@ -3,7 +3,9 @@ package com.example.bootproject.post.domain;
 
 import com.example.bootproject.common.ApplicationYamlRead;
 import com.example.bootproject.post.dto.PostDetailDTO;
+import com.example.bootproject.post.service.PostService;
 import lombok.*;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -43,14 +45,7 @@ public class Post extends BaseEntity {
                 .content(post.getContent())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
-                .modifiableDate(getModifiableDate(post.getCreatedAt()))
+                .modifiableDate(PostService.getModifiableDate(post.getCreatedAt()))
                 .build();
-    }
-
-    public static long getModifiableDate(LocalDateTime date) {
-        LocalDateTime nowDate = LocalDateTime.now();
-        int modifiableDate = ApplicationYamlRead.getModifiableDateValue();
-
-        return modifiableDate - ChronoUnit.DAYS.between(date, nowDate);
     }
 }

--- a/src/main/java/com/example/bootproject/post/domain/Post.java
+++ b/src/main/java/com/example/bootproject/post/domain/Post.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
@@ -31,7 +32,7 @@ public class Post extends BaseEntity {
         }
 
         public PostBuilder content(String content) {
-            if (!title.matches("^.{0,1000}$")) {
+            if (content != null && !content.matches("^.{0,1000}$")) {
                 throw new IllegalArgumentException("Content must be up to 1000 characters.");
             }
             this.content = content;

--- a/src/main/java/com/example/bootproject/post/domain/PostSearch.java
+++ b/src/main/java/com/example/bootproject/post/domain/PostSearch.java
@@ -13,6 +13,5 @@ public class PostSearch {
     private String title;
     private String content;
     private SortOrder sortOrder;
-
 }
 enum SortOrder{ ASC, DESC;}

--- a/src/main/java/com/example/bootproject/post/domain/PostSearch.java
+++ b/src/main/java/com/example/bootproject/post/domain/PostSearch.java
@@ -1,5 +1,6 @@
 package com.example.bootproject.post.domain;
 
+import com.example.bootproject.enums.SortOrder;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,4 +15,3 @@ public class PostSearch {
     private String content;
     private SortOrder sortOrder;
 }
-enum SortOrder{ ASC, DESC;}

--- a/src/main/java/com/example/bootproject/post/dto/PostDetailDTO.java
+++ b/src/main/java/com/example/bootproject/post/dto/PostDetailDTO.java
@@ -20,11 +20,9 @@ public class PostDetailDTO {
     private LocalDateTime updatedAt;
     private Long modifiableDate;
 
-    public static PostUpdateDTO toPostUpdateDTO(PostDetailDTO postDetailDTO) {
-        Long modifiableDate = postDetailDTO.getModifiableDate();
-
+    public PostUpdateDTO toPostUpdateDTO() {
         return PostUpdateDTO.builder()
-                .postDetailDTO(postDetailDTO)
+                .postDetailDTO(this)
                 .message(modifiableDate == 1 ? "No modifications can be made after one day" : modifiableDate + " days left")
                 .build();
     }

--- a/src/main/java/com/example/bootproject/post/dto/PostDetailDTO.java
+++ b/src/main/java/com/example/bootproject/post/dto/PostDetailDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+
 @Builder
 @Getter
 @Setter
@@ -18,4 +19,13 @@ public class PostDetailDTO {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long modifiableDate;
+
+    public static PostUpdateDTO toPostUpdateDTO(PostDetailDTO postDetailDTO) {
+        Long modifiableDate = postDetailDTO.getModifiableDate();
+
+        return PostUpdateDTO.builder()
+                .postDetailDTO(postDetailDTO)
+                .message(modifiableDate == 1 ? "No modifications can be made after one day" : modifiableDate + " days left")
+                .build();
+    }
 }

--- a/src/main/java/com/example/bootproject/post/dto/PostRegistDTO.java
+++ b/src/main/java/com/example/bootproject/post/dto/PostRegistDTO.java
@@ -1,14 +1,20 @@
 package com.example.bootproject.post.dto;
 
+import com.example.bootproject.post.domain.Post;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class PostRegistDTO {
 
     private String title;
     private String content;
+
+    public static Post toPost(PostRegistDTO postRegistDTO) {
+        return Post.builder()
+                .title(postRegistDTO.getTitle())
+                .content(postRegistDTO.getContent())
+                .build();
+    }
 }

--- a/src/main/java/com/example/bootproject/post/dto/PostRegistDTO.java
+++ b/src/main/java/com/example/bootproject/post/dto/PostRegistDTO.java
@@ -17,4 +17,12 @@ public class PostRegistDTO {
                 .content(postRegistDTO.getContent())
                 .build();
     }
+
+    public static Post toPost(Long id, PostRegistDTO postRegistDTO) {
+        return Post.builder()
+                .id(id)
+                .title(postRegistDTO.getTitle())
+                .content(postRegistDTO.getContent())
+                .build();
+    }
 }

--- a/src/main/java/com/example/bootproject/post/dto/PostRegistDTO.java
+++ b/src/main/java/com/example/bootproject/post/dto/PostRegistDTO.java
@@ -11,18 +11,18 @@ public class PostRegistDTO {
     private String title;
     private String content;
 
-    public static Post toPost(PostRegistDTO postRegistDTO) {
+    public Post toPost() {
         return Post.builder()
-                .title(postRegistDTO.getTitle())
-                .content(postRegistDTO.getContent())
+                .title(title)
+                .content(content)
                 .build();
     }
 
-    public static Post toPost(Long id, PostRegistDTO postRegistDTO) {
+    public Post toPost(Long postId) {
         return Post.builder()
-                .id(id)
-                .title(postRegistDTO.getTitle())
-                .content(postRegistDTO.getContent())
+                .id(postId)
+                .title(title)
+                .content(title)
                 .build();
     }
 }

--- a/src/main/java/com/example/bootproject/post/dto/PostUpdateDTO.java
+++ b/src/main/java/com/example/bootproject/post/dto/PostUpdateDTO.java
@@ -1,6 +1,5 @@
 package com.example.bootproject.post.dto;
 
-import com.example.bootproject.post.domain.Post;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/example/bootproject/post/mapper/PostMapper.java
+++ b/src/main/java/com/example/bootproject/post/mapper/PostMapper.java
@@ -10,15 +10,15 @@ import java.util.*;
 public interface PostMapper {
 
     List<Post> selectAllPosts();
-    Long insertPost(Post post);
+    void insertPost(Post post);
 
-    int softDeletePost(Long id);
+    void softDeletePost(Long id);
 
-    int deletePost(Long id);
+    void deletePost(Long id);
 
     Post getPost(Long id);
 
-    Long updatePost(Post post);
+    void updatePost(Post post);
 
     List<Post> selectPostsByKeywords(PostSearch postSearch);
 }

--- a/src/main/java/com/example/bootproject/post/service/PostService.java
+++ b/src/main/java/com/example/bootproject/post/service/PostService.java
@@ -1,6 +1,8 @@
 package com.example.bootproject.post.service;
 
 import com.example.bootproject.common.ApplicationYamlRead;
+import com.example.bootproject.exception.BadRequestException;
+import com.example.bootproject.exception.NotFoundException;
 import com.example.bootproject.post.domain.Post;
 import com.example.bootproject.post.domain.PostSearch;
 import com.example.bootproject.post.dto.PostDetailDTO;
@@ -8,6 +10,7 @@ import com.example.bootproject.post.dto.PostRegistDTO;
 import com.example.bootproject.post.dto.PostUpdateDTO;
 import com.example.bootproject.post.mapper.PostMapper;
 import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +21,8 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class PostService {
 
-    final PostMapper postMapper;
+    @Autowired
+    private PostMapper postMapper;
 
     public List<Post> allPostList() {
         return postMapper.selectAllPosts();
@@ -28,7 +32,7 @@ public class PostService {
         Post post = postMapper.getPost(id);
 
         if (post == null) {
-            throw new IllegalArgumentException("There are no post");
+            throw new NotFoundException("There is no post with id: " + id);
         }
 
         return post;
@@ -38,7 +42,7 @@ public class PostService {
         Post post = getRawPost(id);
 
         if (post.getDeletedAt() != null) {
-            throw new IllegalStateException("Post already deleted");
+            throw new BadRequestException("Post with id " + id + " is already deleted");
         }
 
         return Post.toPostDetailDTO(post);
@@ -69,7 +73,7 @@ public class PostService {
         Post post = new Post(id, postRegistDTO.getTitle(), postRegistDTO.getContent());
 
         if (modifiableDate <= modifiableDateLimit) {
-            throw new IllegalStateException("Posts that are overdue for editing");
+            throw new BadRequestException("Editing is overdue for post with id " + id);
         }
 
         postMapper.updatePost(post);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
       matching-strategy: ant_path_matcher
   datasource:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: jdbc:mysql://localhost:3306/bootproject?useSSL=false&serverTimezone=UTC
+      jdbc-url: jdbc:mysql://localhost:3306/bootproject?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
       username: root
       password: itmsg4u!
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,7 @@ mybatis:
   mapper-locations: classpath:/mapper/**/*.xml
 #  configuration:
 #    jdbc-type-for-null: null
+
+constant-data:
+  modification-limit-value: 0
+  modifiable-date-value: 10

--- a/src/main/resources/mapper/post-mapper.xml
+++ b/src/main/resources/mapper/post-mapper.xml
@@ -19,8 +19,11 @@
         SELECT * FROM post
         WHERE title like CONCAT('%', #{title}, '%') OR title IS NULL
         <choose>
-            <when test='sortOrder.name() == "ASC"'>
+            <when test='sortOrder != null and sortOrder.name() == "ASC"'>
                 ORDER BY created_at ASC
+            </when>
+            <when test='sortOrder != null and sortOrder.name() == "DESC"'>
+                ORDER BY created_at DESC
             </when>
             <otherwise>
                 ORDER BY created_at DESC
@@ -48,7 +51,7 @@
     </update>
 
     <delete id="deletePost" >
-        DELETE FROM post WHERE id = ${id}content
+        DELETE FROM post WHERE id = #{id}
     </delete>
 
 </mapper>

--- a/src/test/java/com/example/bootproject/common/ApplicationYamlReadTest.java
+++ b/src/test/java/com/example/bootproject/common/ApplicationYamlReadTest.java
@@ -1,0 +1,27 @@
+package com.example.bootproject.common;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+@SpringBootTest
+class ApplicationYamlReadTest {
+
+    @Test
+    void modifiableDateTest(){
+        int modifiableDateValue = ApplicationYamlRead.modifiableDateValue;
+
+        System.out.println("modifiableDate : " + modifiableDateValue);
+        assertThat(modifiableDateValue).isEqualTo(10);
+    }
+
+    @Test
+    void modificationLimitTest(){
+        int modificationLimitValue = ApplicationYamlRead.modificationLimitValue;
+
+        System.out.println("modificationLimit : " + modificationLimitValue);
+        assertThat(modificationLimitValue).isZero();
+    }
+
+}

--- a/src/test/java/com/example/bootproject/common/ApplicationYamlReadTest.java
+++ b/src/test/java/com/example/bootproject/common/ApplicationYamlReadTest.java
@@ -13,6 +13,7 @@ class ApplicationYamlReadTest {
         int modifiableDateValue = ApplicationYamlRead.modifiableDateValue;
 
         System.out.println("modifiableDate : " + modifiableDateValue);
+
         assertThat(modifiableDateValue).isEqualTo(10);
     }
 
@@ -21,7 +22,7 @@ class ApplicationYamlReadTest {
         int modificationLimitValue = ApplicationYamlRead.modificationLimitValue;
 
         System.out.println("modificationLimit : " + modificationLimitValue);
+
         assertThat(modificationLimitValue).isZero();
     }
-
 }

--- a/src/test/java/com/example/bootproject/post/controller/PostControllerTest.java
+++ b/src/test/java/com/example/bootproject/post/controller/PostControllerTest.java
@@ -136,7 +136,7 @@ class PostControllerTest {
         Gson gson = new Gson();
         String content = gson.toJson(rPost);
 
-        given(postService.insertPost(any(PostRegistDTO.class))).willReturn(post);
+        given(postService.savePost(any(PostRegistDTO.class))).willReturn(post);
 
         // then
         mockMvc.perform(post("/api/posts")

--- a/src/test/java/com/example/bootproject/post/domain/PostTest.java
+++ b/src/test/java/com/example/bootproject/post/domain/PostTest.java
@@ -2,6 +2,7 @@ package com.example.bootproject.post.domain;
 
 import com.example.bootproject.common.ApplicationYamlRead;
 import com.example.bootproject.post.dto.PostDetailDTO;
+import com.example.bootproject.post.service.PostService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -33,7 +34,7 @@ class PostTest {
         LocalDateTime date = LocalDateTime.of(2023,11,29,0,0);
         long compareDateValue = ApplicationYamlRead.getModifiableDateValue() - ChronoUnit.DAYS.between(date, now);
 
-        long modifiableDate = Post.getModifiableDate(date);
+        long modifiableDate = PostService.getModifiableDate(date);
 
         System.out.println("modifiableDate : " + modifiableDate);
         assertThat(modifiableDate).isEqualTo(compareDateValue);

--- a/src/test/java/com/example/bootproject/post/domain/PostTest.java
+++ b/src/test/java/com/example/bootproject/post/domain/PostTest.java
@@ -1,0 +1,41 @@
+package com.example.bootproject.post.domain;
+
+import com.example.bootproject.common.ApplicationYamlRead;
+import com.example.bootproject.post.dto.PostDetailDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+@SpringBootTest
+class PostTest {
+
+    @Test
+    void toPostDetailDTOTest() {
+        Post post = Post.builder()
+                .id(1L)
+                .title("Test title")
+                .content("Test content")
+                .build();
+
+        PostDetailDTO postDetailDTO = Post.toPostDetailDTO(post);
+
+        assertThat(postDetailDTO.getId()).isEqualTo(1L);
+        assertThat(postDetailDTO.getTitle()).isEqualTo("Test title");
+        assertThat(postDetailDTO.getTitle()).isEqualTo("Test content");
+    }
+
+    @Test
+    void getModifiableDateTest() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime date = LocalDateTime.of(2023,11,29,0,0);
+        long compareDateValue = ApplicationYamlRead.getModifiableDateValue() - ChronoUnit.DAYS.between(date, now);
+
+        long modifiableDate = Post.getModifiableDate(date);
+
+        System.out.println("modifiableDate : " + modifiableDate);
+        assertThat(modifiableDate).isEqualTo(compareDateValue);
+    }
+}

--- a/src/test/java/com/example/bootproject/post/mapper/PostMapperTest.java
+++ b/src/test/java/com/example/bootproject/post/mapper/PostMapperTest.java
@@ -21,17 +21,38 @@ class PostMapperTest {
     PostMapper postMapper;
 
     @Transactional
+    @DisplayName("getPost 게시글 get 테스트")
+    @Test
+    void getPost() {
+        //given
+        Post post = Post.builder()
+                .title("Test getPost")
+                .build();
+
+        postMapper.insertPost(post);
+
+        //when
+        Post postMapperPost = postMapper.getPost(post.getId());
+
+        //then
+        assertThat(postMapperPost.getTitle()).isEqualTo("Test getPost");
+    }
+
+    @Transactional
     @DisplayName("insertPost 게시글 작성 테스트")
     @Test
     void insertPost() {
+        //given
         Post post = Post.builder()
                 .title("Test insertPost")
                 .build();
 
         postMapper.insertPost(post);
 
+        //when
         Post postMapperPost = postMapper.getPost(post.getId());
 
+        //then
         assertThat(postMapperPost.getTitle()).isEqualTo("Test insertPost");
     }
 
@@ -39,6 +60,7 @@ class PostMapperTest {
     @DisplayName("selectAllPosts Post 모든 목록 조회")
     @Test
     void selectAllPosts() {
+        //given
         Post post = Post.builder()
                 .title("Test selectAllPosts")
                 .build();
@@ -47,8 +69,10 @@ class PostMapperTest {
         postMapper.insertPost(post);
         postMapper.insertPost(post);
 
+        //when
         List<Post> posts = postMapper.selectAllPosts();
 
+        //then
         assertThat(posts.size()).isNotZero();
     }
 
@@ -56,37 +80,51 @@ class PostMapperTest {
     @DisplayName("softDeletePost softDelete 테스트")
     @Test
     void softDeletePost() {
+        //given
         Post post = Post.builder()
                 .title("Test softDeletePost")
                 .build();
+
         postMapper.insertPost(post);
         Long id = post.getId();
 
-        postMapper.softDeletePost(id);
+        Post postMapperPost = postMapper.getPost(id);
 
-        assertThat(post.getCreatedAt()).isNotNull();
+        //when
+        postMapper.softDeletePost(postMapperPost.getId());
+
+        System.out.println(postMapperPost.getDeletedAt());
+        System.out.println(postMapperPost.getTitle());
+
+        //then
+        assertThat(postMapperPost.getDeletedAt()).isNull();
     }
 
     @Transactional
     @DisplayName("deletePost 게시글 삭제 테스트")
     @Test
     void deletePost() {
+        //given
         Post post = Post.builder()
                 .title("Test deletePost")
                 .build();
-        postMapper.insertPost(post);
-        Long id = post.getId();
-        postMapper.softDeletePost(id);
 
+        postMapper.insertPost(post);
+
+        Long id = post.getId();
+
+        //when
         postMapper.deletePost(id);
 
+        //then
         assertThat(postMapper.getPost(id)).isNull();
     }
 
     @Transactional
-    @DisplayName("deletePost 게시글 삭제 테스트")
+    @DisplayName("updatePost 게시글 업데이트 테스트")
     @Test
     void updatePost() {
+        //given
         Post post = Post.builder()
                 .title("Test updatePost")
                 .build();
@@ -97,9 +135,11 @@ class PostMapperTest {
                 .title("Title Updated")
                 .build();
 
+        //when
         postMapper.updatePost(changePost);
         Post postMapperPost = postMapper.getPost(id);
 
+        //then
         assertThat(postMapperPost.getTitle()).isEqualTo("Title Updated");
     }
 
@@ -107,19 +147,29 @@ class PostMapperTest {
     @DisplayName("selectPostsByKeywords 게시글 검색 테스트")
     @Test
     void selectPostsByKeywords() {
-        Post post = Post.builder()
+        //given
+        Post postOne = Post.builder()
                 .title("Test selectPostsByKeywords")
                 .build();
-        postMapper.insertPost(post);
-        postMapper.insertPost(post);
-        postMapper.insertPost(post);
-        postMapper.insertPost(post);
-        PostSearch postSearch = PostSearch.builder()
-                .title("Test selectPostsByKeywords")
+        Post postTwo = Post.builder()
+                .title("Test2 selectPostsByKeywords")
+                .build();
+        Post postThree = Post.builder()
+                .title("Test3 selectPostsByKeywords")
                 .build();
 
+        postMapper.insertPost(postOne);
+        postMapper.insertPost(postTwo);
+        postMapper.insertPost(postThree);
+
+        PostSearch postSearch = PostSearch.builder()
+                .title("selectPostsByKeywords")
+                .build();
+
+        //when
         List<Post> posts = postMapper.selectPostsByKeywords(postSearch);
 
-        assertThat(posts.size()).isNotZero();
+        //then
+        assertThat(posts.size()).isEqualTo(3);
     }
 }

--- a/src/test/java/com/example/bootproject/post/mapper/PostMapperTest.java
+++ b/src/test/java/com/example/bootproject/post/mapper/PostMapperTest.java
@@ -1,0 +1,125 @@
+package com.example.bootproject.post.mapper;
+
+import com.example.bootproject.post.domain.Post;
+import com.example.bootproject.post.domain.PostSearch;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Resource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class PostMapperTest {
+
+    @Resource
+    PostMapper postMapper;
+
+    @Transactional
+    @DisplayName("insertPost 게시글 작성 테스트")
+    @Test
+    void insertPost() {
+        Post post = Post.builder()
+                .title("Test insertPost")
+                .build();
+
+        postMapper.insertPost(post);
+
+        Post postMapperPost = postMapper.getPost(post.getId());
+
+        assertThat(postMapperPost.getTitle()).isEqualTo("Test insertPost");
+    }
+
+    @Transactional
+    @DisplayName("selectAllPosts Post 모든 목록 조회")
+    @Test
+    void selectAllPosts() {
+        Post post = Post.builder()
+                .title("Test selectAllPosts")
+                .build();
+
+        postMapper.insertPost(post);
+        postMapper.insertPost(post);
+        postMapper.insertPost(post);
+
+        List<Post> posts = postMapper.selectAllPosts();
+
+        assertThat(posts.size()).isNotZero();
+    }
+
+    @Transactional
+    @DisplayName("softDeletePost softDelete 테스트")
+    @Test
+    void softDeletePost() {
+        Post post = Post.builder()
+                .title("Test softDeletePost")
+                .build();
+        postMapper.insertPost(post);
+        Long id = post.getId();
+
+        postMapper.softDeletePost(id);
+
+        assertThat(post.getCreatedAt()).isNotNull();
+    }
+
+    @Transactional
+    @DisplayName("deletePost 게시글 삭제 테스트")
+    @Test
+    void deletePost() {
+        Post post = Post.builder()
+                .title("Test deletePost")
+                .build();
+        postMapper.insertPost(post);
+        Long id = post.getId();
+        postMapper.softDeletePost(id);
+
+        postMapper.deletePost(id);
+
+        assertThat(postMapper.getPost(id)).isNull();
+    }
+
+    @Transactional
+    @DisplayName("deletePost 게시글 삭제 테스트")
+    @Test
+    void updatePost() {
+        Post post = Post.builder()
+                .title("Test updatePost")
+                .build();
+        postMapper.insertPost(post);
+        Long id = post.getId();
+        Post changePost = Post.builder()
+                .id(id)
+                .title("Title Updated")
+                .build();
+
+        postMapper.updatePost(changePost);
+        Post postMapperPost = postMapper.getPost(id);
+
+        assertThat(postMapperPost.getTitle()).isEqualTo("Title Updated");
+    }
+
+    @Transactional
+    @DisplayName("selectPostsByKeywords 게시글 검색 테스트")
+    @Test
+    void selectPostsByKeywords() {
+        Post post = Post.builder()
+                .title("Test selectPostsByKeywords")
+                .build();
+        postMapper.insertPost(post);
+        postMapper.insertPost(post);
+        postMapper.insertPost(post);
+        postMapper.insertPost(post);
+        PostSearch postSearch = PostSearch.builder()
+                .title("Test selectPostsByKeywords")
+                .build();
+
+        List<Post> posts = postMapper.selectPostsByKeywords(postSearch);
+
+        assertThat(posts.size()).isNotZero();
+    }
+}

--- a/src/test/java/com/example/bootproject/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/bootproject/post/service/PostServiceTest.java
@@ -1,0 +1,302 @@
+package com.example.bootproject.post.service;
+
+import com.example.bootproject.common.ApplicationYamlRead;
+import com.example.bootproject.exception.BadRequestException;
+import com.example.bootproject.exception.NotFoundException;
+import com.example.bootproject.post.domain.Post;
+import com.example.bootproject.post.dto.PostDetailDTO;
+import com.example.bootproject.post.dto.PostRegistDTO;
+import com.example.bootproject.post.dto.PostUpdateDTO;
+import com.example.bootproject.post.mapper.PostMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.doNothing;
+
+@SpringBootTest
+class PostServiceTest {
+
+    //db 상호작용 없이 테스트 진행
+    @Mock
+    private PostMapper postMapper;
+
+    private PostService postService;
+
+    // 매 테스트 마다 진행
+    @BeforeEach
+    void setUp() {
+        //테스트 클래스에 선언된 모든 Mock객체 초기화
+        MockitoAnnotations.initMocks(this);
+        // bootTest 사용하지 않으므로 수동 객체 생성
+        postService = new PostService(postMapper);
+    }
+
+    @DisplayName("getRawPost 성공 테스트")
+    @Test
+    void getRawPost() {
+        //given
+        Long postId = 1L;
+        Post post = Post.builder().id(postId).title("Test getRawPost").build();
+
+        given(postMapper.getPost(postId)).willReturn(post);
+
+        //when
+        Post rawPost = postService.getRawPost(postId);
+
+        //then
+        assertThat(rawPost.getId()).isEqualTo(1L);
+        assertThat(rawPost.getTitle()).isEqualTo("Test getRawPost");
+    }
+
+    @DisplayName("getRawPost 실패 테스트 데이터 없는 경우")
+    @Test
+    void getRawPost_WhenPostDoseNotExist() throws Exception {
+        //given
+        Long postId = 1L;
+
+        given(postMapper.getPost(postId)).willReturn(null);
+
+        //when
+        //then
+        assertThatThrownBy(() -> postService.getRawPost(postId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("There is no post with id: " + postId);
+    }
+
+    @DisplayName("getRawPost 실패 테스트 ID 값이 null인 경우")
+    @Test
+    void getRawPost_WhenPostIdIsNull() throws Exception {
+        //given
+        Long postId = null;
+
+        //when
+        //then
+        assertThatThrownBy(() -> postService.getRawPost(postId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ID cannot be null");
+    }
+
+    @DisplayName("getPost 성공 테스트")
+    @Test
+    void getPost() {
+        //given
+        Long postId = 1L;
+        Post post = Post.builder().id(postId).title("Test getPost").build();
+        post.setCreatedAt(LocalDateTime.now());
+
+        given(postMapper.getPost(postId)).willReturn(post);
+
+        //when
+        PostDetailDTO postDetail = postService.getPost(postId);
+
+        //then
+        assertThat(postDetail.getId()).isEqualTo(1L);
+        assertThat(postDetail.getTitle()).isEqualTo("Test getPost");
+    }
+
+    @DisplayName("getPost 실패 테스트 softDelete 된 경우")
+    @Test
+    void getPost_WhenPostAlreadySoftDeleted() {
+        //given
+        Long postId = 1L;
+        Post post = Post.builder().id(postId).title("Test getPost_WhenPostAlreadySoftDeleted").build();
+        post.setDeletedAt(LocalDateTime.now());
+
+        given(postMapper.getPost(postId)).willReturn(post);
+
+        //when
+        //then
+        assertThatThrownBy(() -> postService.getPost(postId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Post with id " + postId + " is already deleted");
+    }
+
+    @DisplayName("getPost 실패 테스트 데이터 없는 경우")
+    @Test
+    void getPost_WhenPostDoseNotExist() {
+        //given
+        Long postId = 1L;
+        given(postMapper.getPost(postId)).willReturn(null);
+
+        //when
+        //then
+        assertThatThrownBy(() -> postService.getPost(postId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("There is no post with id: " + postId);
+    }
+
+    // db 연결 없이 테스트 하고 싶은데 어떻게 해야할 지 모르겠슴
+//    @Transactional
+//    @DisplayName("savePost 성공 테스트")
+//    @Test
+//    void savePost() {
+//        //given
+//        PostRegistDTO postRegist = PostRegistDTO.builder().title("Test savePost").build();
+//
+//        //when
+//        PostDetailDTO postDetailDTO = postService.savePost(postRegist);
+//        // postMapper를 모킹중이므로 insert를 하더라도 id값이 업데이트 되지 않음
+//
+//        //then
+//        assertThat(postDetailDTO.getTitle()).isEqualTo("Test savePost");
+//    }
+
+    @DisplayName("savePost 성공 테스트")
+    @Test
+    void savePost() {
+        //given
+        PostRegistDTO postRegist = PostRegistDTO.builder().title("Test savePost").build();
+        Post post = Post.builder().id(1L).title("Test savePost").build();
+        post.setCreatedAt(LocalDateTime.now());
+
+        /*
+        * doAnswer : void 메서드에 대한 동작을 정의할 때 사용. 
+        Answer 인터페이스의 구현을 인자로 받으며 호출시 실행될 코드를 포함
+        * invocation : 람다식을 이용하여 Answer 인터페이스의 구현을 제공 실행될 코드 기입. 
+        invocation은 메서드 호출정보를 포함하고 있는 InvocationMock 객체
+        * invocation.getArgument(0) : 모깅된 메서드에 전달 될 첫번째 인자(Post객체)를 가져옴
+        * ReflectionTestUtils : 테스트 환경에서 private 필드를 조작할 때 사용
+        * ReflectionTestUtils.setField(returnPost,"id",1L) : post객체에 id값을 1로 설정
+        * when(postMapper).insertPost(any(Post.class)) : 어떤 Post객체가 들어와도 정의된 동작을 실행하겠다는 의미
+         */
+        doAnswer(invocation -> {
+            Post returnPost = invocation.getArgument(0);
+            ReflectionTestUtils.setField(returnPost, "id", 1L);
+            return null;
+        }).when(postMapper).insertPost(any(Post.class));
+
+        given(postMapper.getPost(anyLong())).willReturn(post);
+
+        //when
+        PostDetailDTO postDetailDTO = postService.savePost(postRegist);
+
+        //then
+        assertThat(postDetailDTO.getTitle()).isEqualTo("Test savePost");
+    }
+
+    @DisplayName("savePost 실패 테스트 Title 200자 이상")
+    @Test
+    void savePost_WhenTileIsMoreThan200() {
+        PostRegistDTO postRegistDTO = PostRegistDTO.builder()
+                .title(String.join("", Collections.nCopies(201, "t")))
+                .build();
+
+        assertThatThrownBy(() -> postService.savePost(postRegistDTO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Content must be up to 200 characters.");
+    }
+
+    @DisplayName("savePost 실패 테스트 Title 1000자 이상")
+    @Test
+    void savePost_WhenContentIsMoreThan1000() {
+        PostRegistDTO postRegistDTO = PostRegistDTO.builder()
+                .title("Test savePost_WhenContentIsMoreThan1000")
+                .content(String.join("", Collections.nCopies(1002, "T")))
+                .build();
+
+        assertThatThrownBy(() -> postService.savePost(postRegistDTO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Content must be up to 1000 characters.");
+    }
+
+    @DisplayName("updatePost 성공 테스트")
+    @Test
+    void updatePost() {
+        // bootrun을 하지 않으면 yml의 상수값을 읽어오지 못해 업데이트가능 날짜를 테스트 할 수 없음
+        // given
+        Long postId = 1L;
+        Post post = Post.builder().id(postId).title("Test updatePost").build();
+        post.setCreatedAt(LocalDateTime.now());
+
+        String changeTitle = "Test updated";
+        PostRegistDTO postRegistDTO = PostRegistDTO.builder().title(changeTitle).build();
+
+        given(postMapper.getPost(anyLong())).willAnswer(invocation -> {
+            post.setTitle(changeTitle);
+            return post;
+        });
+
+        doNothing().when(postMapper).updatePost(any(Post.class));
+
+        //when
+        PostUpdateDTO postUpdate = postService.updatePost(postRegistDTO, postId);
+
+        //then
+        assertThat(postUpdate.getPostDetailDTO().getTitle()).isEqualTo(changeTitle);
+        assertThat(postUpdate.getMessage()).isEqualTo("10 days left");
+    }
+
+    @DisplayName("updatePost 실패 테스트 수정 기한 초과")
+    @Test
+    void updatePost_WhenOverdue() {
+        // given
+        Long postId = 1L;
+        PostRegistDTO postRegist = PostRegistDTO.builder().title("Test updatePost_WhenOverdue").build();
+        Post post = Post.builder().title("Test updatePost_WhenOverdue").build();
+        post.setCreatedAt(LocalDateTime.of(2000, 1, 1, 0, 0, 0));
+
+        given(postMapper.getPost(postId)).willReturn(post);
+
+        // when
+        // then
+        assertThatThrownBy(() -> postService.updatePost(postRegist, postId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Editing is overdue for post with id " + postId);
+
+    }
+
+    @Test
+    void allPostList() {
+    }
+
+    @Test
+    void postListSearch() {
+    }
+
+    @DisplayName("deletePost 성공 테스트")
+    @Test
+    void deletePost() {
+        // mapper 테스트와 완전 동일 하고 모킹 한다면 따로 테스트 할 게 없는데 테스트 해야 하나요?
+    }
+
+    @DisplayName("softDeletePost 실패 테스트 이미 softDelete 된 게시물")
+    @Test
+    void softDeletePost_WhenAlreadyDeleted() {
+        //given
+        Long postId = 1L;
+        Post post = Post.builder().id(postId).title("Test SoftDelete Fail").build();
+        post.setDeletedAt(LocalDateTime.now());
+
+        given(postMapper.getPost(postId)).willReturn(post);
+
+        //when then
+        assertThatThrownBy(() -> postService.softDeletePost(postId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("The post with id " + postId + " has already been deleted");
+    }
+
+    @DisplayName("getModifiableDate 성공 테스트")
+    @Test
+    void getModifiableDate() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime testDate = LocalDateTime.of(2023, 11, 29, 0, 0);
+        long result = ApplicationYamlRead.getModifiableDateValue() - ChronoUnit.DAYS.between(testDate, now);
+
+        //when then
+        assertThat(postService.getModifiableDate(testDate)).isEqualTo(result);
+    }
+}


### PR DESCRIPTION
### 피드백 반영 수정 리스트

1. 코드 컨벤션 수정 - 개행, 한글사용, 변수명등 
2. ReponseEntity 왜 사용하는지 공부하고 꼭 필요한 곳에만 사용하기
3. Service 로직 역할에 맞게 수정
4. 적절한 에러 처리 사용

### ResponseEntity.created(URI)
insert 컨트롤러를 수정하면서 ResponseEntity.created() 를 사용하여 201 status code를 날려주고 싶었다. 
created(URI) 메소드를 확인해보니 URI값을 파라미터로 받고 있었는데 무엇을 넣어줘야 할지 몰라 찾아보았더니
201 status code는 새로운 자원을 성공적으로 생성했다는 의미이며 해당 URI값은 생성된 자원에 접근할 수 있는 식별자가 포함된 URI를 반환하겠다는 의미였다.
식별자를 반환하는 방법에는 두 가지가 있었는데 
1. 생성된 자원에 접근할 수 있는 URI값을 반환하는 것
2. 생성된 자원을 반환하는 것

두 가지 방법 중 기존 코드에서 이미 생성된 자원을 반환하고 있었기 때문에 created()메소드를 사용하지 않고 status(HttpStatus.CREATED)를 사용하여 상태코드를 날려주고 body에 생성된 자원을 넣어 응답했다.
1번 방법을 사용하면 다시 자원을 검색하여 반환하지 않아도 된다는 장점이 있다고 생각되고 2번 방법의 경우 클라이언트가 자원에 접근하기 위한 API를 다시 날려주지 않아도 된다는 장점이 있는 것 같은데 어떤 방식이 더 좋은지 잘 모르겠다.
